### PR TITLE
fix: mriqc now comes from nipreps

### DIFF
--- a/singularity-manifest.yml
+++ b/singularity-manifest.yml
@@ -3,6 +3,6 @@ docker:
 - bids/validator
 - brownbnc/xnat-tools
 - nipreps/fmriprep
-- poldracklab/mriqc
+- nipreps/mriqc
 - nipreps/dmriprep
 - halfpipe/halfpipe


### PR DESCRIPTION
Hello @elizabethlorenc and @fordmcdonald. This is a tiny PR to change where mriqc image is pulled from. I tagged you mostly so you know this file exists and is what gets passed to the script that syncs in Oscar [here](SINGULARITY_REGISTRY_URL="https://raw.githubusercontent.com/brown-bnc/bnc-resource-registry/master/singularity-manifest.yml")