### PR TITLE
add dcm4che tools

### DIFF
--- a/singularity-manifest.yml
+++ b/singularity-manifest.yml
@@ -7,3 +7,4 @@ docker:
 - nipreps/dmriprep
 - halfpipe/halfpipe
 - pennlinc/aslprep
+- dcm4che/dcm4che-tools


### PR DESCRIPTION
most useful is emf2sf function, which can convert enhanced multiframe 3D DICOMs to legacy DICOMs (doesn't work for EPIs)